### PR TITLE
Display route on map when activity starts

### DIFF
--- a/quickRouteMap/src/main/java/com/dpm/quickroutemap/QuickRouteMapActivity.java
+++ b/quickRouteMap/src/main/java/com/dpm/quickroutemap/QuickRouteMapActivity.java
@@ -166,6 +166,10 @@ public final class QuickRouteMapActivity extends Activity implements IGuidancePr
         _mapOverlayManager.add(_myLocationOverlay);
 
         _guidanceManager = GuidanceManager.getInstance();
+        _currentRoute = _guidanceManager.getCurrentRoute();
+        if (_currentRoute != null) {
+            showRoute();
+        }
 
         checkPermissions();
 
@@ -255,7 +259,7 @@ public final class QuickRouteMapActivity extends Activity implements IGuidancePr
         clear();
         _currentRoute = null;
         _currentRouteUri = null;
-        _guidanceManager.setCurrentRouteGuidance(null);
+        _guidanceManager.setCurrentRoute(null);
         _mapView.invalidate();
         invalidateOptionsMenu();
     }
@@ -271,7 +275,7 @@ public final class QuickRouteMapActivity extends Activity implements IGuidancePr
 
         try {
             _currentRoute = _routeSerializer.fromJson(reader, Route.class);
-            _guidanceManager.setCurrentRouteGuidance(_currentRoute.getGuidancePoints());
+            _guidanceManager.setCurrentRoute(_currentRoute);
 
             showRoute();
 
@@ -415,7 +419,7 @@ public final class QuickRouteMapActivity extends Activity implements IGuidancePr
         } else {
             // Actualizar los puntos de guiado en el gestor de proximidad al terminar de
             // editar
-            _guidanceManager.setCurrentRouteGuidance(_currentRoute.getGuidancePoints());
+            _guidanceManager.setCurrentRoute(_currentRoute);
         }
     }
 

--- a/quickRouteMap/src/main/java/com/dpm/quickroutemap/navigation/GuidanceManager.java
+++ b/quickRouteMap/src/main/java/com/dpm/quickroutemap/navigation/GuidanceManager.java
@@ -2,7 +2,7 @@ package com.dpm.quickroutemap.navigation;
 
 public class GuidanceManager implements IGuidanceProvider{
 
-    private GuidancePoint[] _route;
+    private Route _route;
     private IGuidanceConsumer _consumer;
 
     private static GuidanceManager _instance = null;
@@ -20,15 +20,29 @@ public class GuidanceManager implements IGuidanceProvider{
         _consumer = consumer;
     }
 
-    public void setCurrentRouteGuidance(GuidancePoint[] routeGuidance) {
-        _route = routeGuidance;
+    public void setCurrentRoute(Route route) {
+        _route = route;
         if (_consumer != null){
-            _consumer.setCurrentRouteGuidance(_route);
+            _consumer.setCurrentRouteGuidance(_route != null ? _route.getGuidancePoints() : null);
+        }
+    }
+
+    public Route getCurrentRoute() {
+        return _route;
+    }
+
+    public void setCurrentRouteGuidance(GuidancePoint[] routeGuidance) {
+        if (_route == null) {
+            _route = new Route();
+        }
+        _route.setGuidancePoints(routeGuidance);
+        if (_consumer != null){
+            _consumer.setCurrentRouteGuidance(routeGuidance);
         }
     }
 
     @Override
     public GuidancePoint[] getCurrentRouteGuidance() {
-        return _route;
+        return _route != null ? _route.getGuidancePoints() : null;
     }
 }

--- a/quickRouteMap/src/test/java/com/dpm/quickroutemap/tests/GuidanceManagerTest.java
+++ b/quickRouteMap/src/test/java/com/dpm/quickroutemap/tests/GuidanceManagerTest.java
@@ -3,6 +3,7 @@ package com.dpm.quickroutemap.tests;
 import com.dpm.quickroutemap.navigation.GuidanceManager;
 import com.dpm.quickroutemap.navigation.GuidancePoint;
 import com.dpm.quickroutemap.navigation.IGuidanceConsumer;
+import com.dpm.quickroutemap.navigation.Route;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -48,5 +49,33 @@ public class GuidanceManagerTest {
         manager.setCurrentRouteGuidance(points);
         
         Assert.assertArrayEquals(points, manager.getCurrentRouteGuidance());
+    }
+
+    @Test
+    public void setCurrentRoute_StoresAndReturnsRoute() {
+        GuidanceManager manager = GuidanceManager.getInstance();
+        Route route = new Route();
+        route.setName("Test Route");
+        route.setGuidancePoints(new GuidancePoint[0]);
+        
+        manager.setCurrentRoute(route);
+        
+        Assert.assertSame(route, manager.getCurrentRoute());
+        Assert.assertNotNull(manager.getCurrentRouteGuidance());
+    }
+
+    @Test
+    public void setCurrentRoute_WithConsumer_NotifiesConsumer() {
+        GuidanceManager manager = GuidanceManager.getInstance();
+        IGuidanceConsumer consumer = Mockito.mock(IGuidanceConsumer.class);
+        Route route = new Route();
+        GuidancePoint[] points = new GuidancePoint[]{new GuidancePoint("k1", 1, 1, "n1")};
+        route.setGuidancePoints(points);
+        
+        manager.setConsumer(consumer);
+        manager.setCurrentRoute(route);
+        
+        Mockito.verify(consumer).setCurrentRouteGuidance(points);
+        Assert.assertSame(route, manager.getCurrentRoute());
     }
 }


### PR DESCRIPTION
Before this change, when a route was loaded and the main activity disposed and opened again, the current reoute was not displayed.

After this change, if the main activity is closed and re-opened again later, the route is displayed whenever the route was loaded previously.